### PR TITLE
Fix steps parameter

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,7 +227,7 @@ $(function() {
         _.each(vars, function(v) {
             var v = v.split('='),
                 key = v[0], val = v[1];
-            if (key == 'steps') $('#steps,#steps-div').val(val);
+            if (key == 'steps') $('#steps,#steps-div,#steps-seq').val(val);
             else if (key == 'colors') $('#colors').val(val);
             else if (key == 'c0') $('#colors-left').val(val);
             else if (key == 'c1') $('#colors-right').val(val);


### PR DESCRIPTION
When visiting https://gka.github.io/palettes/#colors=#000,#f0f,#fff|steps=21|bez=0|coL=0 , "Step count" is immediately set to 7 and not picked up by the url. This PR fixes this issue.

Resolves https://github.com/gka/palettes/issues/2